### PR TITLE
Fixes: Creates course data when quests fetched & returns valid IDs for QuestSets on first fetch

### DIFF
--- a/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/persistence/entity/quests/QuestSetEntity.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/persistence/entity/quests/QuestSetEntity.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 @AllArgsConstructor
 public class QuestSetEntity implements IWithId<UUID> {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     /**


### PR DESCRIPTION
## Description of changes
Please provide a short description of the change or if the change is sufficiently described in the GitHub issue, provide a link to the issue.
* Fixes a bug where a user's course data isn't created when they fetch their quests, leading to a crash if course data hasn't previously been created by other means (e.g. by running another quest beforehand which does create course data)
* Fixes a bug where a QuestSet's returned ID is null when the quest set has been "freshly" generated (i.e. not persisted in the DB yet)
  
## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [ ] automated unit test
- [ ] automated integration test
- [x] manual, exploratory test

* Visited course with a new User account and ensured that course data is now created for the user without needing to reload the course page
* Checked that the query fetching a QuestSet returns a valid ID even if the QuestSet is generated anew as part of the query
    
## Checklist before requesting a review

- [ ] My code is easy to understand
- [ ] My code follows the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] My code fulfills all acceptance criteria
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/MEITREX/wiki/tree/main/adr)
- [ ] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
