### PR TITLE
Prevent tutor speeches of over 255 chars in length from crashing

### DIFF
--- a/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/persistence/entity/TutorImmersiveSpeechEmbeddable.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/persistence/entity/TutorImmersiveSpeechEmbeddable.java
@@ -1,5 +1,6 @@
 package de.unistuttgart.iste.meitrex.gamification_service.persistence.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.Data;
 
@@ -8,6 +9,8 @@ import java.time.OffsetDateTime;
 @Embeddable
 @Data
 public class TutorImmersiveSpeechEmbeddable {
+    @Column(columnDefinition = "TEXT")
     private String recentActivitiesString;
+    @Column(columnDefinition = "TEXT")
     private String tutorSpeechContent;
 }


### PR DESCRIPTION
## Description of changes
Hibernate by default creates a varchar(255) column for strings. Sometimes, the LLM creates a tutor speech over 255 chars in length. This prevents it from being persisted and results in an exception. This PR instructs hibernate to create a TEXT column instead, which does not have a text length limitation.

  
## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [ ] automated unit test
- [ ] automated integration test
- [x] manual, exploratory test
    
## Checklist before requesting a review

- [ ] My code is easy to understand
- [ ] My code follows the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] My code fulfills all acceptance criteria
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/MEITREX/wiki/tree/main/adr)
- [ ] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
