### PR TITLE
Fix MoveLeaderboardGoalProgressEvent missing user id when raised

### DIFF
--- a/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/service/reactive/leaderboard/UserProgressUpdatedLeaderboardListener.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/service/reactive/leaderboard/UserProgressUpdatedLeaderboardListener.java
@@ -168,6 +168,7 @@ public class UserProgressUpdatedLeaderboardListener extends AbstractInternalList
             int newRank = newRankOptional.get();
             if(oldRank != newRank) {
                 goalProgressUpdater.updateGoalProgressEntitiesForUser(userEntity, courseEntity.getId(), MoveLeaderboardGoalProgressEvent.builder()
+                        .userId(userEntity.getId())
                         .oldRank(oldRank)
                         .newRank(newRank)
                         .build()


### PR DESCRIPTION
## Description of changes
Previously, the code which raises MoveLeaderboardGoalProgressEvent  forgot to pass the user id, leading to the event not being able to be correctly processed by subscribers.

  
## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [ ] automated unit test
- [ ] automated integration test
- [x] manual, exploratory test

Tested that move leaderboard event is now able to be correctly handled by quest system (quest can now be completed)
    
## Checklist before requesting a review

- [ ] My code is easy to understand
- [ ] My code follows the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] My code fulfills all acceptance criteria
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/MEITREX/wiki/tree/main/adr)
- [ ] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
