### PR TITLE
Add debug properties to force specific quests to get generated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,10 +119,10 @@ repositories {
 
 dependencies {
 
-    implementation 'de.unistuttgart.iste.meitrex:meitrex-common'
-    implementation 'de.unistuttgart.iste.meitrex:content_service'
-    implementation 'de.unistuttgart.iste.meitrex:course_service'
-    implementation 'de.unistuttgart.iste.meitrex:user_service'
+    implementation 'de.unistuttgart.iste.meitrex:meitrex-common:1.4.9'
+    implementation 'de.unistuttgart.iste.meitrex:content_service:1.5.0rc7'
+    implementation 'de.unistuttgart.iste.meitrex:course_service:1.1.0rc2'
+    implementation 'de.unistuttgart.iste.meitrex:user_service:1.0.0rc1'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-graphql'
@@ -139,7 +139,7 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'de.unistuttgart.iste.meitrex:meitrex-common-test:1.4.6'
+    testImplementation 'de.unistuttgart.iste.meitrex:meitrex-common-test:1.4.9'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework:spring-webflux'
     testImplementation 'org.springframework.graphql:spring-graphql-test'

--- a/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/config/DebugAdaptivityConfiguration.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/config/DebugAdaptivityConfiguration.java
@@ -1,0 +1,27 @@
+package de.unistuttgart.iste.meitrex.gamification_service.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@ConfigurationProperties("debug.app.adaptivity")
+@Configuration
+public class DebugAdaptivityConfiguration {
+    private Quests quests = new Quests();
+
+    @Data
+    public static class Quests {
+        /**
+         * Forces daily quest generation to exclusively generate the specified quest type.
+         * Must be one of: "EXERCISE", "LEARNING", "SPECIALTY" or null to disable forcing.
+         */
+        private String forceDailyQuestType = null;
+        /**
+         * Forces specialty quest generation to exclusively generate the specified quest type.
+         * Must be one of: "ALTRUISM", "ASSISTANCE", "CUSTOMIZATION", "IMMERSION", "INCENTIVE", "PROGRESSION",
+         * "RISK_REWARD", "SOCIALIZATION", or null to disable forcing.
+         */
+        private String forceSpecialtyQuestType = null;
+    }
+}

--- a/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/dapr/AskedTutorAQuestionEventListener.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/dapr/AskedTutorAQuestionEventListener.java
@@ -11,7 +11,11 @@ import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 @RestController
 public class AskedTutorAQuestionEventListener extends AbstractExternalListener<AskedTutorAQuestionEvent> {
@@ -30,8 +34,9 @@ public class AskedTutorAQuestionEventListener extends AbstractExternalListener<A
     @Transactional
     @Topic(name = "asked-tutor-a-question", pubsubName = "meitrex")
     @PostMapping(path = "/asked-tutor-a-question-pubsub")
-    public void onAskedTutorAQuestionEvent(CloudEvent<AskedTutorAQuestionEvent> event) {
-        super.handle(event, AskedTutorAQuestionEventListener::getContext, null);
+    public void onAskedTutorAQuestionEvent(@RequestBody CloudEvent<AskedTutorAQuestionEvent> event,
+                                           @RequestHeader Map<String, String> headers) {
+        super.handle(event, AskedTutorAQuestionEventListener::getContext, headers);
     }
 
     @Override

--- a/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/service/internal/quests/quest_generation/SpecialtyDailyQuestGeneratorService.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/service/internal/quests/quest_generation/SpecialtyDailyQuestGeneratorService.java
@@ -1,5 +1,6 @@
 package de.unistuttgart.iste.meitrex.gamification_service.service.internal.quests.quest_generation;
 
+import de.unistuttgart.iste.meitrex.gamification_service.config.DebugAdaptivityConfiguration;
 import de.unistuttgart.iste.meitrex.gamification_service.persistence.entity.CourseEntity;
 import de.unistuttgart.iste.meitrex.gamification_service.persistence.entity.UserEntity;
 import de.unistuttgart.iste.meitrex.gamification_service.persistence.entity.achievements.goals.*;
@@ -25,12 +26,21 @@ public class SpecialtyDailyQuestGeneratorService implements IDailyQuestGenerator
     private final IRecommendationCreator recommendationCreator;
     private final SpecialtyQuestGoalGeneratorFactory specialtyQuestGoalGeneratorFactory;
 
+    private final DebugAdaptivityConfiguration debugAdaptivityConfiguration;
+
     @Override
     public Optional<QuestEntity> generateQuest(CourseEntity courseEntity,
                                                UserEntity userEntity,
                                                List<QuestEntity> otherQuests) {
-        GamificationCategory recommendationCategory = recommendationCreator.makeRecommendation(
-                userEntity.getId(), courseEntity.getId(), RecommendationType.DAILY_QUEST);
+        GamificationCategory recommendationCategory;
+
+        if(debugAdaptivityConfiguration.getQuests().getForceSpecialtyQuestType() != null) {
+            recommendationCategory = GamificationCategory.valueOf(
+                    debugAdaptivityConfiguration.getQuests().getForceSpecialtyQuestType());
+        } else {
+            recommendationCategory = recommendationCreator.makeRecommendation(
+                    userEntity.getId(), courseEntity.getId(), RecommendationType.DAILY_QUEST);
+        }
 
         log.info("Generating specialty daily quest for user {} in course {} with recommendation category {}",
                 userEntity.getId(), courseEntity.getId(), recommendationCategory);

--- a/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/service/quests/QuestService.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/service/quests/QuestService.java
@@ -2,6 +2,7 @@ package de.unistuttgart.iste.meitrex.gamification_service.service.quests;
 
 import de.unistuttgart.iste.meitrex.content_service.exception.ContentServiceConnectionException;
 import de.unistuttgart.iste.meitrex.gamification_service.config.AdaptivityConfiguration;
+import de.unistuttgart.iste.meitrex.gamification_service.config.DebugAdaptivityConfiguration;
 import de.unistuttgart.iste.meitrex.gamification_service.persistence.entity.CourseEntity;
 import de.unistuttgart.iste.meitrex.gamification_service.persistence.entity.UserCourseDataEntity;
 import de.unistuttgart.iste.meitrex.gamification_service.persistence.entity.UserEntity;
@@ -10,8 +11,6 @@ import de.unistuttgart.iste.meitrex.gamification_service.persistence.entity.achi
 import de.unistuttgart.iste.meitrex.gamification_service.persistence.entity.achievements.userGoalProgress.UserGoalProgressEntity;
 import de.unistuttgart.iste.meitrex.gamification_service.persistence.entity.quests.QuestEntity;
 import de.unistuttgart.iste.meitrex.gamification_service.persistence.entity.quests.QuestSetEntity;
-import de.unistuttgart.iste.meitrex.gamification_service.persistence.repository.ICourseRepository;
-import de.unistuttgart.iste.meitrex.gamification_service.persistence.repository.IUserRepository;
 import de.unistuttgart.iste.meitrex.gamification_service.quests.DailyQuestType;
 import de.unistuttgart.iste.meitrex.gamification_service.service.internal.ICourseCreator;
 import de.unistuttgart.iste.meitrex.gamification_service.service.internal.ICourseMembershipHandler;
@@ -43,6 +42,7 @@ public class QuestService implements IQuestService{
     private final ICourseCreator courseCreator;
 
     private final AdaptivityConfiguration adaptivityConfiguration;
+    private final DebugAdaptivityConfiguration debugAdaptivityConfiguration;
 
     private final QuestGeneratorServiceFactory questGeneratorServiceFactory;
 
@@ -86,8 +86,15 @@ public class QuestService implements IQuestService{
 
         int rewardPoints = (int)(adaptivityConfiguration.getQuestBaseRewardPoints() * rewardMultiplier);
 
-        List<DailyQuestType> questTypeCandidates = new ArrayList<>(Arrays.stream(DailyQuestType.values()).toList());
-        Collections.shuffle(questTypeCandidates);
+        List<DailyQuestType> questTypeCandidates;
+
+        if(debugAdaptivityConfiguration.getQuests().getForceSpecialtyQuestType() != null) {
+            questTypeCandidates = new ArrayList<>(List.of(
+                    DailyQuestType.valueOf(debugAdaptivityConfiguration.getQuests().getForceDailyQuestType())));
+        } else {
+            questTypeCandidates = new ArrayList<>(Arrays.stream(DailyQuestType.values()).toList());
+            Collections.shuffle(questTypeCandidates);
+        }
 
         List<QuestEntity> quests = new ArrayList<>();
         while (quests.size() < DAILY_QUEST_COUNT) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,3 +43,8 @@ app.adaptivity.immersive-tutor-speech-generic=Let's work on some stuff!
 app.adaptivity.widget-recommendation-default-feedback-request-interval-days=8
 app.adaptivity.widget-recommendation-min-feedback-request-interval-days=8
 app.adaptivity.widget-recommendation-max-feedback-request-interval-days=30
+
+# These properties can be used to force certain quest types for testing purposes. Hover the properties for more
+# information using your IDE.
+#debug.app.adaptivity.quests.force-daily-quest-type=SPECIALTY
+#debug.app.adaptivity.quests.force-specialty-quest-type=SOCIALIZATION


### PR DESCRIPTION
## Description of changes
This PR adds 2 debug properties which can be set in application.properties. These properties allow us to force a specific quest to be generated (instead of the quest being picked procedurally depending on the user's progress and player type). This is useful when testing if a particular quest implementation works.

  
## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [ ] automated unit test
- [ ] automated integration test
- [x] manual, exploratory test

## Checklist before requesting a review

- [ ] My code is easy to understand
- [ ] My code follows the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] My code fulfills all acceptance criteria
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/MEITREX/wiki/tree/main/adr)
- [ ] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
