### PR TITLE
Exercise Quest: Fixes a bug when trying to generate quest for passed assessment

### DIFF
--- a/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/service/internal/quests/quest_generation/ExerciseDailyQuestGeneratorService.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/gamification_service/service/internal/quests/quest_generation/ExerciseDailyQuestGeneratorService.java
@@ -36,7 +36,9 @@ public class ExerciseDailyQuestGeneratorService implements IDailyQuestGenerator 
             new AssessmentMapKey(AssessmentUserStatus.FAILED, false),
             new AssessmentMapKey(AssessmentUserStatus.NOT_WORKED_ON, false),
             new AssessmentMapKey(AssessmentUserStatus.PASSED_PAST_LEARNING_INTERVAL, true),
-            new AssessmentMapKey(AssessmentUserStatus.PASSED_PAST_LEARNING_INTERVAL, false)
+            new AssessmentMapKey(AssessmentUserStatus.PASSED_PAST_LEARNING_INTERVAL, false),
+            new AssessmentMapKey(AssessmentUserStatus.PASSED, true),
+            new AssessmentMapKey(AssessmentUserStatus.PASSED, false)
     );
 
     public Optional<QuestEntity> generateQuest(final CourseEntity courseEntity,
@@ -129,7 +131,10 @@ public class ExerciseDailyQuestGeneratorService implements IDailyQuestGenerator 
      */
     private Optional<Assessment> pickAssessmentRandomly(final Map<AssessmentMapKey, List<Assessment>> foundAssessments,
                                                         final float pickProbability) {
-        for (AssessmentMapKey key : assessmentImportanceOrder) {
+        for (final AssessmentMapKey key : assessmentImportanceOrder) {
+            if(key.status == AssessmentUserStatus.PASSED)
+                continue; // we do not want to suggest passed assessments
+
             final List<Assessment> assessments = foundAssessments.get(key);
             if(Math.random() <= pickProbability && !assessments.isEmpty()) {
                 for(Assessment assessment : assessments) {


### PR DESCRIPTION
## Description of changes
This PR fixes a bug with Exercise Quest generation. This bug caused quest generation to fail if only passed assessments are available and thus no non-passed assessments could be found to generate a quest for.

  
## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [ ] automated unit test
- [ ] automated integration test
- [x] manual, exploratory test
    
## Checklist before requesting a review

- [ ] My code is easy to understand
- [ ] My code follows the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] My code fulfills all acceptance criteria
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/MEITREX/wiki/tree/main/adr)
- [ ] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
